### PR TITLE
added in required cookie secret to keystone config

### DIFF
--- a/keystone.js
+++ b/keystone.js
@@ -20,7 +20,8 @@ keystone.init({
 	'auto update': true,
 	'session': true,
 	'auth': true,
-	'user model': 'User'
+	'user model': 'User',
+	'cookie secret': '(your secret here)'
 
 });
 


### PR DESCRIPTION
This prevents an error upon trying to run the app after cloning. 
